### PR TITLE
Add instructions to reproduce the book locally into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,27 @@
 # Geocomputation with Julia
 
 [![Render](https://github.com/geocompx/geocompjl/actions/workflows/main.yaml/badge.svg)](https://github.com/geocompx/geocompjl/actions/workflows/main.yaml)
+
+Geocomputation with Julia is an open source book project. We are developing it in the open and publishing an up-to-date online version at https://jl.geocompx.org/.
+Geocomputation with Julia is part of the [geocompx](https://geocompx.org/) series providing geocomputation resources in different languages.
+
+## Reproducing the book locally
+
+To run the code that is part of the Geocomputation with Julia book requires the following dependencies:
+
+1. Julia: To install julia on your machine we recommend to use juliaup which can be installed follwing these [installation instructions](https://julialang.org/downloads/)
+For now we need to restrict to julia 1.10 because quarto 1.5 does not work with julia 1.11
+To restrict the julia version for this project folder run
+```
+juliaup override set 1.10
+```
+
+2. [Quarto](https://quarto.org/docs/get-started/), which is used to
+    render the book. This needs quarto 1.5.30 or higher
+3. Julia Dependencies:
+    To install the julia dependencies run the following in the main folder of this project:
+    ```
+    julia --project -e "using Pkg; Pkg.instantiate()"
+    ```
+
+

--- a/chapters/01-spatial-data.qmd
+++ b/chapters/01-spatial-data.qmd
@@ -1,7 +1,5 @@
 ---
 engine: julia
-project:
-  execute-dir: project
 ---
 
 # Geographic data in Julia {#sec-spatial-class}
@@ -20,7 +18,7 @@ mkpath("output")
 ## Introduction
 ```{julia}
 using GeoDataFrames
-df = GeoDataFrames.read("data/world.gpkg")
+df = GeoDataFrames.read("../data/world.gpkg")
 ```
 
 ```{julia}
@@ -130,7 +128,7 @@ For now, for completeness, and also to use these rasters in subsequent chapters 
 In the case of `elev`, we do it as follows with the `Rasters.write` functions and methods of the **Rasters.jl** package.
 
 ```{julia}
-write("output/elev.tif", elev_raster; force = true)
+write("../output/elev.tif", elev_raster; force = true)
 ```
 
 Note that the CRS we (arbitrarily) set for the `elev` raster is WGS84, defined using `crs=4326` according to the EPSG code.
@@ -138,7 +136,7 @@ Note that the CRS we (arbitrarily) set for the `elev` raster is WGS84, defined u
 Exporting the `grain` raster is done in the same way, with the only differences being the file name and the array we write into the connection.
 
 ```{julia}
-write("output/grain.tif", Raster(grain, (new_x, new_y); crs = GFT.EPSG(4326)); force = true)
+write("../output/grain.tif", Raster(grain, (new_x, new_y); crs = GFT.EPSG(4326)); force = true)
 ```
 
 As a result, the files `elev.tif` and `grain.tif` are written into the `output` directory.

--- a/chapters/05-raster-vector.qmd
+++ b/chapters/05-raster-vector.qmd
@@ -33,17 +33,17 @@ Makie.set_theme!(
 It also relies on the following data files:
 
 ```{julia}
-src_srtm = Raster("data/srtm.tif")
-src_nlcd = Raster("data/nlcd.tif")
-src_grain = Raster("output/grain.tif")
-src_elev = Raster("output/elev.tif")
-src_dem = Raster("data/dem.tif")
-zion = GeoDataFrames.read("data/zion.gpkg")
-zion_points = GeoDataFrames.read("data/zion_points.gpkg")
-cycle_hire_osm = GeoDataFrames.read("data/cycle_hire_osm.gpkg")
-us_states = GeoDataFrames.read("data/us_states.gpkg")
-nz = GeoDataFrames.read("data/nz.gpkg")
-src_nz_elev = Raster("data/nz_elev.tif")
+src_srtm = Raster("../data/srtm.tif")
+src_nlcd = Raster("../data/nlcd.tif")
+src_grain = Raster("../output/grain.tif")
+src_elev = Raster("../output/elev.tif")
+src_dem = Raster("../data/dem.tif")
+zion = GeoDataFrames.read("../data/zion.gpkg")
+zion_points = GeoDataFrames.read("../data/zion_points.gpkg")
+cycle_hire_osm = GeoDataFrames.read("../data/cycle_hire_osm.gpkg")
+us_states = GeoDataFrames.read("../data/us_states.gpkg")
+nz = GeoDataFrames.read("../data/nz.gpkg")
+src_nz_elev = Raster("../data/nz_elev.tif")
 ```
 
 ## Introduction
@@ -146,7 +146,7 @@ out_image_mask = Rasters.mask(src_srtm; with = zion, missingval = 9999)
 We can write this masked raster to file with `Rasters.write`:
 
 ```{julia}
-Rasters.write("output/srtm_masked.tif", out_image_mask; force = true
+Rasters.write("../output/srtm_masked.tif", out_image_mask; force = true
 )
 ```
 
@@ -170,7 +170,7 @@ out_image_mask_crop = Rasters.crop(out_image_mask; to = zion, touches = true)
 and we write it to file using `Rasters.write`:
 
 ```{julia}
-Rasters.write("output/srtm_masked_cropped.tif", out_image_mask_crop; force = true)
+Rasters.write("../output/srtm_masked_cropped.tif", out_image_mask_crop; force = true)
 ```
 
 @fig-raster-crop shows the original raster, and the three masking and/or cropping results.
@@ -750,7 +750,7 @@ One [suggestion](https://gis.stackexchange.com/questions/455980/vectorizing-all-
 To transform a raster to points, Rasters.jl provides the `Rasters.DimTable` constructor, which converts a raster into a lazy, table-like form.  This can be converted directly to a `DataFrame`, or operated on independently.
 
 ```{julia}
-dt = DimTable(Raster("output/elev.tif"))
+dt = DimTable(Raster("../output/elev.tif"))
 ```
 
 Notice that this has three columns, `:X`, `:Y`, and `:layer1`, corresponding to the pixel centroids and elevation values.  But what if we want to treat the X and Y dimensionas as point geometries?
@@ -758,7 +758,7 @@ Notice that this has three columns, `:X`, `:Y`, and `:layer1`, corresponding to 
 `DimTable` has a `mergedims` keyword argument for this, which allows us to merge the X and Y dimensions into a single dimension.
 
 ```{julia}
-dt = DimTable(Raster("output/elev.tif"), mergedims = (X, Y))
+dt = DimTable(Raster("../output/elev.tif"), mergedims = (X, Y))
 ```
 
 This has created a `DimTable` with a column `:XY`, which contains the pixel centroids as point-like objects.  We can convert this to a `DataFrame`, set some metadata to indicate that geometry is in `:XY`, and plot the result.
@@ -776,8 +776,8 @@ scatter(df.XY; color = df.layer1)
 We can even save this to a file trivially easily:
 
 ```{julia}
-GeoDataFrames.write("output/elev.gpkg", df)
-GeoDataFrames.read("output/elev.gpkg")
+GeoDataFrames.write("../output/elev.gpkg", df)
+GeoDataFrames.read("../output/elev.gpkg")
 ```
 
 


### PR DESCRIPTION
This also sets the paths in the notebooks to move one folder up, so that the output and data folder are project wise. This can be removed once execute-dir works.

This works for me locally now with quarto 1.5.57 and julia 1.10

