### PR TITLE
Add Dependabot and bump outdated actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear cache
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             console.log("About to clear")

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to monitor GitHub Actions versions weekly, grouped into a single PR per run
- Bump `actions/checkout` v3 → v5 in `main.yaml` and `pr.yaml`
- Bump `actions/github-script` v6 → v7 in `clear_cache.yml`

Once this lands, Dependabot will pick up any further version drift on its weekly cadence (and an admin can also force a run from the Insights → Dependency graph → Dependabot tab).

## Test plan
- [ ] Confirm `Quarto Publish` workflow still runs on push to main
- [ ] Confirm `Quarto PR Publish` workflow still runs on PR
- [ ] Verify Dependabot is enabled in repo settings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)